### PR TITLE
修复原先捕捉不到请求端错误的问题;

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -28,9 +28,16 @@ var request = function(options, params, callback) {
       buf.push(data);
     });
     res.on('error', function(err) {
+      //response error event
       callback(err);
     });
   });
+  
+  req.on('error', function(err) {
+    //request error event
+    callback(err);
+  });
+  
   if (params) {
     var stringify;
     if (options.headers['Content-Type'] && options.headers['Content-Type'].toLowerCase() == 'application/x-www-form-urlencoded') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yhsd-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Youhaosuda API SDK for node.",
   "main": "index.js",
   "repository": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,8 +1,6 @@
 /**
  * Created by obzerg on 16/1/5.
  */
-var http = require('http');
-var bluebird = require('bluebird');
 var should = require('should');
 var Yhsd = require('../index');
 
@@ -109,7 +107,7 @@ describe('test/api.test.js', function () {
         })
     });
   
-    it('api should be return connect ETIMEDOUT error', function (done) {
+    it('api should be throw ENOTFOUND error', function (done) {
         Yhsd.config.apiHost = 'localhost:32876';
         Yhsd.config.appHost = 'localhost:32876';
         Yhsd.config.httpProtocol = 'http';
@@ -124,6 +122,7 @@ describe('test/api.test.js', function () {
             }
           }
           console.log(token);
+          done(new Error('没有捕捉到错误!'));
         });
     });
   
@@ -155,5 +154,5 @@ describe('test/api.test.js', function () {
     //    }
     //    _request();
     //});
-  });
+});
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,8 @@
 /**
  * Created by obzerg on 16/1/5.
  */
+var http = require('http');
+var bluebird = require('bluebird');
 var should = require('should');
 var Yhsd = require('../index');
 
@@ -106,7 +108,25 @@ describe('test/api.test.js', function () {
             done();
         })
     });
-
+  
+    it('api should be return connect ETIMEDOUT error', function (done) {
+        Yhsd.config.apiHost = 'localhost:32876';
+        Yhsd.config.appHost = 'localhost:32876';
+        Yhsd.config.httpProtocol = 'http';
+        api.get('products',function (err, token) {
+          if (err){
+            // console.log(err.message);
+            var eResult = err.message.indexOf('ENOTFOUND');
+            if (eResult > 0) {
+              (eResult).should.be.ok();
+              done();
+              return;
+            }
+          }
+          console.log(token);
+        });
+    });
+  
     //it('api should be return error code 429', function (done) {
     //    var total = 0;
     //    function _request() {
@@ -135,5 +155,5 @@ describe('test/api.test.js', function () {
     //    }
     //    _request();
     //});
-});
+  });
 


### PR DESCRIPTION
原先没用监控request的error事件,导致服务宕掉.这个 pull request 解决该问题.
完善原测试用例;